### PR TITLE
Set proper caching headers for avatars

### DIFF
--- a/lib/Controller/MastodonAPIController.php
+++ b/lib/Controller/MastodonAPIController.php
@@ -96,7 +96,9 @@ class MastodonAPIController extends Controller {
      * @NoCSRFRequired
      */
     public function getMastodonAvatar($url) {
-        return new DataDisplayResponse($this->mastodonAPIService->getMastodonAvatar($url));
+        $response = new DataDisplayResponse($this->mastodonAPIService->getMastodonAvatar($url));
+        $response->cacheFor(60*60*24);
+        return $response;
     }
 
     /**


### PR DESCRIPTION
The same would of course make sense for all other apps that fetch avatars from 3rdparty service.